### PR TITLE
Fix crash if barcode isn't set

### DIFF
--- a/mam-info.c
+++ b/mam-info.c
@@ -206,9 +206,7 @@ int main(int argc, char * argv[])
         }
 */
         if(att_read(sg_fd, medium.barcode, MAM_ATT_BARCODE, 12, MAM_TYPE_ASCII) < 0) {
-                printf("ERROR : Read failed (try verbose opt)\n");
-                close(sg_fd);
-                return -1;
+                medium.barcode[0] = '\0';
         }
 /*
         if(att_read(sg_fd, medium.identifier, MAM_ATT_IDENTIFIER, 12, MAM_TYPE_ASCII) < 0) {


### PR DESCRIPTION
If a tape does not have a barcode set, my IBM drive throws a Check Condition status:

```
ERROR : Problem reading attribute 0806
SG_READ_ATT command error: SCSI status: Check Condition 
Fixed format, current; Sense key: Illegal Request
Additional sense: Invalid field in cdb
  Field replaceable unit code: 48
  Sense Key Specific: Error in Command: byte 8 bit 7
 Raw sense data (in hex), sb_len=32, embedded_len=96
        70 00 05 00 00 00 00 58  00 00 00 00 24 00 30 cf
        00 08 00 00 0e 00 20 20  20 20 20 20 20 00 00 00
        00 00 00 65 04 06 81 00  08 32 30 31 34 30 35 30
        37 04 07 80 00 08 00 00  00 00 00 00 40 00 04 08
        80 00 01 00 04 09 80 00  02 00 00 10 00 80 00 1c
        d7 59 04 24 47 36 41 42  41 58 31 39 46 55 4a 49
```

This PR handles this by setting the barcode buffer to an empty string and continuing, so mam-info can display the rest of the cartridge data.